### PR TITLE
fix: no need to pin NumPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ Package license: BSD-3-Clause
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/boost-histogram-feedstock/blob/master/LICENSE.txt)
 
-Summary: The Boost::Histogram Python wrapper.
+Summary: The official Boost.Histogram Python bindings. Provides fast, efficient
+histogramming with a variety of different storages combined with dozens of
+composable axes. Part of the [Scikit-HEP](https://scikit-hep.org) family.
+
 
 Development: https://github.com/scikit-hep/boost-histogram
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: eb2205e7cac21c3742b19ea147359c588e07a4f3b719d58c6ad6009fee423fce
 
 build:
-  number: 0
+  number: 1
   script: NPY_NUM_BUILD_JOBS=1 {{ PYTHON }} -m pip install . -vvv  # [linux and ppc64le]
   script: {{ PYTHON }} -m pip install . -vvv  # [not (linux and ppc64le)]
 
@@ -24,7 +24,6 @@ requirements:
   run:
     - python
     - numpy
-    - {{ pin_compatible('numpy') }}
 
 test:
   source_files:
@@ -42,7 +41,10 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: The Boost::Histogram Python wrapper.
+  summary: |
+    The official Boost.Histogram Python bindings. Provides fast, efficient
+    histogramming with a variety of different storages combined with dozens of
+    composable axes. Part of the [Scikit-HEP](https://scikit-hep.org) family.
   dev_url: https://github.com/scikit-hep/boost-histogram
   doc_url: https://boost-histogram.readthedocs.io
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Tiny bit of cleanup (no pinning of NumPy needed), and slightly longer description.

I wasn't able to rerender, got this error:

<details>
<summary>Click to expand</summary>

```
INFO:conda_smithy.configure_feedstock:Downloading conda-forge-pinning-2020.10.28.12.21.23
INFO:conda_smithy.configure_feedstock:Extracting conda-forge-pinning to /var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/tmp53e8wqyi
Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
WARNING:conda_build.config:Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
Setting build arch. This is only useful when pretending to be on another arch, such as for rendering necessary dependencies on a non-native arch. I trust that you know what you're doing.
WARNING:conda_build.config:Setting build arch. This is only useful when pretending to be on another arch, such as for rendering necessary dependencies on a non-native arch. I trust that you know what you're doing.
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from internal_defaults
Adding in variants from /var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/tmp53e8wqyi/conda_build_config.yaml
INFO:conda_build.variants:Adding in variants from /var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/tmp53e8wqyi/conda_build_config.yaml
INFO:conda_smithy.configure_feedstock:Applying migrations: /var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/tmp53e8wqyi/share/conda-forge/migrations/pypy.yaml,/var/folders/_8/xtbws09n017fbzdx9dmgnyyr0000gn/T/tmp53e8wqyi/share/conda-forge/migrations/python39.yaml
Adding in variants from argument_variants
INFO:conda_build.variants:Adding in variants from argument_variants
Traceback (most recent call last):
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/cli.py", line 613, in main
    args.subcommand_func(args)
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/cli.py", line 419, in __call__
    self._call(args, tmpdir)
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/cli.py", line 430, in _call
    temporary_directory=temporary_directory,
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/configure_feedstock.py", line 1938, in main
    render_travis(env, config, forge_dir, return_metadata=True)
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/configure_feedstock.py", line 1082, in render_travis
    return_metadata=return_metadata,
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/configure_feedstock.py", line 675, in _render_ci_provider
    metas, forge_dir, platform, arch, upload, forge_config
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/configure_feedstock.py", line 421, in dump_subspace_config_files
    forge_config,
  File "/usr/local/Caskroom/miniconda/base/envs/conda-build/lib/python3.7/site-packages/conda_smithy/configure_feedstock.py", line 363, in _collapse_subpackage_variants
    "ignore_build_only_deps",
TypeError: explode_variants() got an unexpected keyword argument 'extend_keys'
```

</details>