### PR TITLE
Replace cmake <4.4 pin with CMP0190=NEW + emulator for cp314t cross builds

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,8 +23,8 @@ build:
     - if: build_platform != target_platform
       then: |
         ${{ PYTHON }} -m pip install . -v \
-          --config-settings=cmake.define.CMAKE_POLICY_DEFAULT_CMP0190=NEW \
-          --config-settings=cmake.define.CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+          -Ccmake.define.CMAKE_POLICY_DEFAULT_CMP0190=NEW \
+          -Ccmake.define.CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
       else: ${{ PYTHON }} -m pip install . -v
 
 requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,11 +13,19 @@ source:
   sha256: 43d5c4c07315390b4a751165fa1fb00faafcc06c9da5442115063fba0e6130b1
 
 build:
-  number: 0
+  number: 1
   script:
     - if: not win and not (linux and ppc64le)
       then: export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
-    - ${{ PYTHON }} -m pip install . -v
+    # CMP0190=NEW + an emulator lets cmake 4.4 FindPython query the (runnable)
+    # target interpreter when cross-compiling; without it the free-threaded
+    # include dir is rejected (Python_FIND_ABI now always defined, gil=OFF)
+    - if: build_platform != target_platform
+      then: |
+        ${{ PYTHON }} -m pip install . -v \
+          --config-settings=cmake.define.CMAKE_POLICY_DEFAULT_CMP0190=NEW \
+          --config-settings=cmake.define.CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+      else: ${{ PYTHON }} -m pip install . -v
 
 requirements:
   build:
@@ -27,9 +35,7 @@ requirements:
         - cross-python_${{ target_platform }}
     - ${{ compiler('cxx') }}
     - ${{ stdlib("c") }}
-    # cmake 4.4 FindPython rejects free-threaded Python when cross-compiling
-    # (always-defined Python_FIND_ABI defaults to gil=OFF)
-    - cmake <4.4
+    - cmake
     - if: not win
       then: make
   host:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Alternative workaround for the CMake 4.4 FindPython regression that broke cross-compiled free-threaded builds (see #71). Instead of pinning `cmake <4.4`, pass `CMAKE_POLICY_DEFAULT_CMP0190=NEW` and `CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env` via scikit-build-core config-settings when `build_platform != target_platform`. With CMP0190 NEW and an emulator defined, FindPython queries the target interpreter (which is runnable in conda-forge cross builds), so it derives the correct free-threaded ABI flags and accepts `include/python3.14t`. Bumps the build number.

Verified against a minimal reproducer on cmake 4.4.2; the cross cp314t jobs in CI are the real test here.